### PR TITLE
feat: allow ctx.session to be undefined

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_size = 4
+indent_style = space
+insert_final_newline = true

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,7 +4,7 @@
     "exports": "./mod.ts",
     "lock": false,
     "tasks": {
-        "check": "deno cache --allow-import src/mod.ts",
+        "check": "deno cache --allow-import mod.ts",
         "test": "deno test --allow-import test",
         "ok": "deno fmt && deno lint && deno task test && deno task check",
         "clean": "git clean -fX out test/cov_profile test/coverage coverage.lcov",

--- a/mod.ts
+++ b/mod.ts
@@ -234,7 +234,7 @@ function strictSingleSession<S, C extends Context>(
         );
         const key = await getSessionKey(ctx);
         await propSession.init(key, { custom, lazy: false });
-        await next(); // no catch: do not write back if middleware throws
+        await next(); // no catch: do not write back if middleware
         await propSession.finish();
     };
 }
@@ -260,7 +260,7 @@ function strictMultiSession<S, C extends Context>(
             await s.init(key, { custom, lazy: false });
             return s;
         }));
-        await next(); // no catch: do not write back if middleware throws
+        await next(); // no catch: do not write back if middleware
         if (ctx.session === undefined) propSessions.forEach((s) => s.delete());
         await Promise.all(propSessions.map((s) => s.finish()));
     };
@@ -379,8 +379,7 @@ class PropertySession<O extends {}, P extends keyof O> {
             enumerable: true,
             get: () => {
                 if (key === undefined) {
-                    const msg = undef("access", opts);
-                    throw new Error(msg);
+                    return undefined;
                 }
                 this.read = true;
                 if (!opts.lazy || this.wrote) return this.value;
@@ -389,7 +388,7 @@ class PropertySession<O extends {}, P extends keyof O> {
             },
             set: (v) => {
                 if (key === undefined) {
-                    const msg = undef("assign", opts);
+                    const msg = undef("access", opts);
                     throw new Error(msg);
                 }
                 this.wrote = true;

--- a/test/mod.test.ts
+++ b/test/mod.test.ts
@@ -33,23 +33,26 @@ describe("session", () => {
         assertEquals(middleware.calls[0].args[0], ctx);
     });
 
-    it("should throw when reading from empty session key", async () => {
+    it("should return undefined when reading from empty session key", async () => {
         type C = Context & SessionFlavor<number>;
         let composer = new Composer<C>();
-        const ctx = {} as C;
-        composer.use(session(), () => ctx.session);
-        await assertRejects(async () => {
-            await composer.middleware()(ctx, next);
+        let ctx = {} as C;
+        composer.use(session(), () => {
+            assertEquals(ctx.session, undefined);
         });
 
+        await composer.middleware()(ctx, next);
+
+        ctx = {} as C;
         composer = new Composer<C>();
         composer.use(
             session({ getSessionKey: () => undefined }),
-            () => ctx.session,
+            () => {
+                assertEquals(ctx.session, undefined);
+            },
         );
-        await assertRejects(async () => {
-            await composer.middleware()(ctx, next);
-        });
+
+        await composer.middleware()(ctx, next);
     });
 
     it("should throw when writing to empty session key", async () => {
@@ -268,29 +271,30 @@ describe("multi session", () => {
         assertEquals(middleware.calls[0].args[0], ctx);
     });
 
-    it("should throw when reading from empty session key", async () => {
+    it("should return undefined when reading from empty session key", async () => {
         type C = Context & SessionFlavor<{ prop: number }>;
         let composer = new Composer<C>();
-        const ctx = {} as C;
+        let ctx = {} as C;
         composer.use(
             session({ type: "multi", prop: {} }),
-            () => ctx.session.prop,
+            () => {
+                assertEquals(ctx.session.prop, undefined);
+            },
         );
-        await assertRejects(async () => {
-            await composer.middleware()(ctx, next);
-        });
 
+        ctx = {} as C;
         composer = new Composer<C>();
         composer.use(
             session({
                 type: "multi",
                 prop: { getSessionKey: () => undefined },
             }),
-            () => ctx.session.prop,
+            () => {
+                assertEquals(ctx.session.prop, undefined);
+            },
         );
-        await assertRejects(async () => {
-            await composer.middleware()(ctx, next);
-        });
+
+        await composer.middleware()(ctx, next);
     });
 
     it("should throw when writing to empty session key", async () => {
@@ -493,23 +497,24 @@ describe("lazy session", () => {
         assertEquals(middleware.calls[0].args[0], ctx);
     });
 
-    it("should throw when reading from empty session key", async () => {
+    it("should return undefined when reading from empty session key", async () => {
         type C = Context & LazySessionFlavor<number>;
         let composer = new Composer<C>();
-        const ctx = {} as C;
-        composer.use(lazySession(), () => ctx.session);
-        await assertRejects(async () => {
-            await composer.middleware()(ctx, next);
+        let ctx = {} as C;
+        composer.use(lazySession(), () => {
+            assertEquals(ctx.session, undefined);
         });
 
+        ctx = {} as C;
         composer = new Composer<C>();
         composer.use(
             lazySession({ getSessionKey: () => undefined }),
-            () => ctx.session,
+            () => {
+                assertEquals(ctx.session, undefined);
+            },
         );
-        await assertRejects(async () => {
-            await composer.middleware()(ctx, next);
-        });
+
+        await composer.middleware()(ctx, next);
     });
 
     it("should throw when writing to empty session key", async () => {


### PR DESCRIPTION
Ported from [#769](https://github.com/grammyjs/grammY/pull/769) on the core repo.

Closes https://github.com/grammyjs/session/issues/5.